### PR TITLE
Update: 移动qiankunding参数至pipeline_utils

### DIFF
--- a/gts_engine/gts_common/pipeline_utils.py
+++ b/gts_engine/gts_common/pipeline_utils.py
@@ -22,6 +22,10 @@ def download_model_from_huggingface(pretrained_model_dir, model_name, model_clas
     print("model %s is downloaded from huggingface." % model_name)
 
 def generate_common_trainer(args: GtsEngineArgs, save_path):
+    args.num_sanity_val_steps = 1000 
+    args.accumulate_grad_batches = 8 
+    args.val_check_interval = 0.5 
+    print('args', args)
     # Prepare Trainer
     checkpoint = ModelCheckpoint(dirpath=save_path,
                                     save_top_k=1,
@@ -38,10 +42,13 @@ def generate_common_trainer(args: GtsEngineArgs, save_path):
 
     logger = loggers.TensorBoardLogger(save_dir=os.path.join(save_path, 'logs/'))
     trainer = Trainer(
-        max_epochs=args.max_epochs,
-        min_epochs=args.min_epochs,
-        logger=logger,
-        callbacks=[checkpoint, early_stop]
+                        logger=logger,
+                        callbacks=[checkpoint, early_stop],
+                        min_epochs=args.min_epochs,
+                        max_epochs=args.max_epochs,
+                        num_sanity_val_steps=args.num_sanity_val_steps,
+                        accumulate_grad_batches=args.accumulate_grad_batches,
+                        val_check_interval=args.val_check_interval
     )
     return trainer, checkpoint
 

--- a/gts_engine/gts_common/pipeline_utils.py
+++ b/gts_engine/gts_common/pipeline_utils.py
@@ -48,7 +48,8 @@ def generate_common_trainer(args: GtsEngineArgs, save_path):
                         max_epochs=args.max_epochs,
                         num_sanity_val_steps=args.num_sanity_val_steps,
                         accumulate_grad_batches=args.accumulate_grad_batches,
-                        val_check_interval=args.val_check_interval
+                        val_check_interval=args.val_check_interval,
+                        gpus=args.gpus
     )
     return trainer, checkpoint
 

--- a/gts_engine/gts_engine_train.py
+++ b/gts_engine/gts_engine_train.py
@@ -115,10 +115,6 @@ def main():
 
     print("pretrained_model_dir", args.pretrained_model_dir)
     args.gpus = 1
-    args.num_sanity_val_steps = 1000 
-    args.accumulate_grad_batches = 8 
-    args.val_check_interval = 0.5 
-    print('args', args)
     torch.set_num_threads(8)
     
     # main(args)


### PR DESCRIPTION
移动乾坤鼎训练特定参数至pipeline_utils，使相应参数仅关联乾坤鼎的trainer
<img width="617" alt="image" src="https://user-images.githubusercontent.com/20498668/207307467-ac7512d2-c953-42e3-a91a-45820526129f.png">
